### PR TITLE
Fix: TanStack Query defaultMutationOptions runtime error

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
   "dependencies": {
     "@astrojs/react": "^4.4.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@tanstack/react-query": "4.38.0",
+    "@tanstack/query-core": "4.38.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/lib/queryClient.js
+++ b/src/lib/queryClient.js
@@ -1,0 +1,18 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export function createQueryClient(overrides = {}) {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 2,
+        retryDelay: attempt => Math.min(1000 * 2 ** attempt, 30000),
+        staleTime: 30000,
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: 1,
+      },
+      ...overrides,
+    },
+  });
+}


### PR DESCRIPTION
Create QueryClient factory and pin v4; replace legacy usage